### PR TITLE
Update code examples to use single quotes

### DIFF
--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -61,9 +61,9 @@ set the current user, "forget" is used to sign out our users.
 
 Now we have everything ready to implement our actual view::
 
-    @view_config(route_name='auth', match_param="action=in", renderer="string",
-                 request_method="POST")
-    @view_config(route_name='auth', match_param="action=out", renderer="string")
+    @view_config(route_name='auth', match_param='action=in', renderer='string',
+                 request_method='POST')
+    @view_config(route_name='auth', match_param='action=out', renderer='string')
     def sign_in_out(request):
         username = request.POST.get('username')
         if username:

--- a/docs/authentication_src.rst
+++ b/docs/authentication_src.rst
@@ -18,14 +18,14 @@ This is how views.py should look like at this point::
         Entry
         )
     
-    @view_config(route_name='home', renderer="pyramid_blogr:templates/index.mako")
+    @view_config(route_name='home', renderer='pyramid_blogr:templates/index.mako')
     def index_page(request):
         page = int(request.params.get('page', 1))
         paginator = Entry.get_paginator(request, page)
         return {'paginator':paginator}
     
     
-    @view_config(route_name='blog', renderer="pyramid_blogr:templates/view_blog.mako")
+    @view_config(route_name='blog', renderer='pyramid_blogr:templates/view_blog.mako')
     def blog_view(request):
         id = int(request.matchdict.get('id', -1))
         entry = Entry.by_id(id)
@@ -34,8 +34,8 @@ This is how views.py should look like at this point::
         return {'entry':entry}
     
     
-    @view_config(route_name='blog_action', match_param="action=create",
-                 renderer="pyramid_blogr:templates/edit_blog.mako",
+    @view_config(route_name='blog_action', match_param='action=create',
+                 renderer='pyramid_blogr:templates/edit_blog.mako',
                  permission='create')
     def blog_create(request):
         entry = Entry()
@@ -47,8 +47,8 @@ This is how views.py should look like at this point::
         return {'form':form, 'action':request.matchdict.get('action')}
     
     
-    @view_config(route_name='blog_action', match_param="action=edit",
-                 renderer="pyramid_blogr:templates/edit_blog.mako",
+    @view_config(route_name='blog_action', match_param='action=edit',
+                 renderer='pyramid_blogr:templates/edit_blog.mako',
                  permission='edit')
     def blog_update(request):
         id = int(request.params.get('id', -1))
@@ -63,9 +63,9 @@ This is how views.py should look like at this point::
         return {'form':form, 'action':request.matchdict.get('action')}
     
     
-    @view_config(route_name='auth', match_param="action=in", renderer="string",
-                 request_method="POST")
-    @view_config(route_name='auth', match_param="action=out", renderer="string")
+    @view_config(route_name='auth', match_param='action=in', renderer='string',
+                 request_method='POST')
+    @view_config(route_name='auth', match_param='action=out', renderer='string')
     def sign_in_out(request):
         username = request.POST.get('username')
         if username:

--- a/docs/authorization.rst
+++ b/docs/authorization.rst
@@ -103,13 +103,13 @@ Now the finishing touch, we set "create" and "edit" permissions on our views.
 
 For this we need to change our view_config decorators like this::
 
-    @view_config(route_name='blog_action', match_param="action=create",
-                 renderer="pyramid_blogr:templates/edit_blog.mako",
+    @view_config(route_name='blog_action', match_param='action=create',
+                 renderer='pyramid_blogr:templates/edit_blog.mako',
                  permission='create')
                  ...
                  
-    @view_config(route_name='blog_action', match_param="action=edit",
-                 renderer="pyramid_blogr:templates/edit_blog.mako",
+    @view_config(route_name='blog_action', match_param='action=edit',
+                 renderer='pyramid_blogr:templates/edit_blog.mako',
                  permission='edit')
                  ...
              

--- a/docs/authorization_src.rst
+++ b/docs/authorization_src.rst
@@ -49,14 +49,14 @@ This is how views.py should look like at this point::
         Entry
         )
     
-    @view_config(route_name='home', renderer="pyramid_blogr:templates/index.mako")
+    @view_config(route_name='home', renderer='pyramid_blogr:templates/index.mako')
     def index_page(request):
         page = int(request.params.get('page', 1))
         paginator = Entry.get_paginator(request, page)
         return {'paginator':paginator}
     
     
-    @view_config(route_name='blog', renderer="pyramid_blogr:templates/view_blog.mako")
+    @view_config(route_name='blog', renderer='pyramid_blogr:templates/view_blog.mako')
     def blog_view(request):
         id = int(request.matchdict.get('id', -1))
         entry = Entry.by_id(id)
@@ -65,8 +65,8 @@ This is how views.py should look like at this point::
         return {'entry':entry}
     
     
-    @view_config(route_name='blog_action', match_param="action=create",
-                 renderer="pyramid_blogr:templates/edit_blog.mako",
+    @view_config(route_name='blog_action', match_param='action=create',
+                 renderer='pyramid_blogr:templates/edit_blog.mako',
                  permission='create')
     def blog_create(request):
         entry = Entry()
@@ -78,8 +78,8 @@ This is how views.py should look like at this point::
         return {'form':form, 'action':request.matchdict.get('action')}
     
     
-    @view_config(route_name='blog_action', match_param="action=edit",
-                 renderer="pyramid_blogr:templates/edit_blog.mako",
+    @view_config(route_name='blog_action', match_param='action=edit',
+                 renderer='pyramid_blogr:templates/edit_blog.mako',
                  permission='edit')
     def blog_update(request):
         id = int(request.params.get('id', -1))
@@ -94,8 +94,8 @@ This is how views.py should look like at this point::
         return {'form':form, 'action':request.matchdict.get('action')}
     
     
-    @view_config(route_name='auth', match_param="action=in", renderer="string",
-                 request_method="POST")
-    @view_config(route_name='auth', match_param="action=out", renderer="string")
+    @view_config(route_name='auth', match_param='action=in', renderer='string',
+                 request_method='POST')
+    @view_config(route_name='auth', match_param='action=out', renderer='string')
     def sign_in_out(request):
         return {}

--- a/docs/blog_create_and_update_view.rst
+++ b/docs/blog_create_and_update_view.rst
@@ -54,8 +54,8 @@ Lets start by importing our freshly created form schemas to views.py::
 
 Next we implement actual view callable that will handle new entries for us::
 
-    @view_config(route_name='blog_action', match_param="action=create",
-                 renderer="pyramid_blogr:templates/edit_blog.mako")
+    @view_config(route_name='blog_action', match_param='action=create',
+                 renderer='pyramid_blogr:templates/edit_blog.mako')
     def blog_create(request): 
         entry = Entry()
         form = BlogCreateForm(request.POST)
@@ -82,8 +82,8 @@ Create update entry view
 
 The following view will handle updates to existing blog entries::
 
-    @view_config(route_name='blog_action', match_param="action=edit",
-                 renderer="pyramid_blogr:templates/edit_blog.mako")
+    @view_config(route_name='blog_action', match_param='action=edit',
+                 renderer='pyramid_blogr:templates/edit_blog.mako')
     def blog_update(request):
         id = int(request.params.get('id', -1))
         entry = Entry.by_id(id)

--- a/docs/blog_create_and_update_view_src.rst
+++ b/docs/blog_create_and_update_view_src.rst
@@ -33,14 +33,14 @@ Contents of views.py::
         Entry
         )
     
-    @view_config(route_name='home', renderer="pyramid_blogr:templates/index.mako")
+    @view_config(route_name='home', renderer='pyramid_blogr:templates/index.mako')
     def index_page(request):
         page = int(request.params.get('page', 1))
         paginator = Entry.get_paginator(request, page)
         return {'paginator':paginator}
     
     
-    @view_config(route_name='blog', renderer="pyramid_blogr:templates/view_blog.mako")
+    @view_config(route_name='blog', renderer='pyramid_blogr:templates/view_blog.mako')
     def blog_view(request):
         id = int(request.matchdict.get('id', -1))
         entry = Entry.by_id(id)
@@ -49,8 +49,8 @@ Contents of views.py::
         return {'entry':entry}
     
     
-    @view_config(route_name='blog_action', match_param="action=create",
-                 renderer="pyramid_blogr:templates/edit_blog.mako")
+    @view_config(route_name='blog_action', match_param='action=create',
+                 renderer='pyramid_blogr:templates/edit_blog.mako')
     def blog_create(request):
         entry = Entry()
         form = BlogCreateForm(request.POST)
@@ -61,8 +61,8 @@ Contents of views.py::
         return {'form':form, 'action':request.matchdict.get('action')}
     
     
-    @view_config(route_name='blog_action', match_param="action=edit",
-                 renderer="pyramid_blogr:templates/edit_blog.mako")
+    @view_config(route_name='blog_action', match_param='action=edit',
+                 renderer='pyramid_blogr:templates/edit_blog.mako')
     def blog_update(request):
         id = int(request.params.get('id', -1))
         entry = Entry.by_id(id)
@@ -76,8 +76,8 @@ Contents of views.py::
         return {'form':form, 'action':request.matchdict.get('action')}
     
     
-    @view_config(route_name='auth', match_param="action=in", renderer="string",
-                 request_method="POST")
-    @view_config(route_name='auth', match_param="action=out", renderer="string")
+    @view_config(route_name='auth', match_param='action=in', renderer='string',
+                 request_method='POST')
+    @view_config(route_name='auth', match_param='action=out', renderer='string')
     def sign_in_out(request):
         return {}

--- a/docs/blog_models_and_views.rst
+++ b/docs/blog_models_and_views.rst
@@ -83,7 +83,7 @@ First lets add our Entry model to imports in views.py::
 
 Now it's time to implement our actual index view::
 
-    @view_config(route_name='home', renderer="pyramid_blogr:templates/index.mako")
+    @view_config(route_name='home', renderer='pyramid_blogr:templates/index.mako')
     def index_page(request):
         page = int(request.params.get('page', 1))
         paginator = Entry.get_paginator(request, page)
@@ -228,7 +228,7 @@ Those exceptions will be used to perform redirects inside our apps.
 
 ::
 
-    @view_config(route_name='blog', renderer="pyramid_blogr:templates/view_blog.mako")
+    @view_config(route_name='blog', renderer='pyramid_blogr:templates/view_blog.mako')
     def blog_view(request):
         id = int(request.matchdict.get('id', -1))
         entry = Entry.by_id(id)

--- a/docs/blog_models_and_views_src.rst
+++ b/docs/blog_models_and_views_src.rst
@@ -82,14 +82,14 @@ Contents of views.py::
         Entry
         )
     
-    @view_config(route_name='home', renderer="pyramid_blogr:templates/index.mako")
+    @view_config(route_name='home', renderer='pyramid_blogr:templates/index.mako')
     def index_page(request):
         page = int(request.params.get('page', 1))
         paginator = Entry.get_paginator(request, page)
         return {'paginator':paginator}
     
     
-    @view_config(route_name='blog', renderer="pyramid_blogr:templates/view_blog.mako")
+    @view_config(route_name='blog', renderer='pyramid_blogr:templates/view_blog.mako')
     def blog_view(request):
         id = int(request.matchdict.get('id', -1))
         entry = Entry.by_id(id)
@@ -98,20 +98,20 @@ Contents of views.py::
         return {'entry':entry}
     
     
-    @view_config(route_name='blog_action', match_param="action=create",
-                 renderer="pyramid_blogr:templates/edit_blog.mako")
+    @view_config(route_name='blog_action', match_param='action=create',
+                 renderer='pyramid_blogr:templates/edit_blog.mako')
     def blog_create(request):
         return {}
     
     
-    @view_config(route_name='blog_action', match_param="action=edit",
-                 renderer="pyramid_blogr:templates/edit_blog.mako")
+    @view_config(route_name='blog_action', match_param='action=edit',
+                 renderer='pyramid_blogr:templates/edit_blog.mako')
     def blog_update(request):
         return {}
     
     
-    @view_config(route_name='auth', match_param="action=in", renderer="string",
-                 request_method="POST")
-    @view_config(route_name='auth', match_param="action=out", renderer="string")
+    @view_config(route_name='auth', match_param='action=in', renderer='string',
+                 request_method='POST')
+    @view_config(route_name='auth', match_param='action=out', renderer='string')
     def sign_in_out(request):
         return {}

--- a/docs/initial_views.rst
+++ b/docs/initial_views.rst
@@ -21,7 +21,7 @@ code in next chapters.
 
 ::
 
-    @view_config(route_name='home', renderer="pyramid_blogr:templates/index.mako")
+    @view_config(route_name='home', renderer='pyramid_blogr:templates/index.mako')
     def index_page(request):
         return {}
     
@@ -49,7 +49,7 @@ form of *package_name:path_to_template*.
 
 ::
 
-    @view_config(route_name='blog', renderer="pyramid_blogr:templates/view_blog.mako")
+    @view_config(route_name='blog', renderer='pyramid_blogr:templates/view_blog.mako')
     def blog_view(request):
         return {}
         
@@ -61,8 +61,8 @@ to our blog entries.
 
 ::
 
-    @view_config(route_name='blog_action', match_param="action=create",
-                 renderer="pyramid_blogr:templates/edit_blog.mako")
+    @view_config(route_name='blog_action', match_param='action=create',
+                 renderer='pyramid_blogr:templates/edit_blog.mako')
     def blog_create(request):
         return {}
 
@@ -76,8 +76,8 @@ And then we have the view for */blog/edit* URL.
 
 ::
 
-    @view_config(route_name='blog_action', match_param="action=edit",
-                 renderer="pyramid_blogr:templates/edit_blog.mako")
+    @view_config(route_name='blog_action', match_param='action=edit',
+                 renderer='pyramid_blogr:templates/edit_blog.mako')
     def blog_update(request):
         return {}
 
@@ -88,9 +88,9 @@ And then we have the view for */blog/edit* URL.
 
 ::
 
-    @view_config(route_name='auth', match_param="action=in", renderer="string",
-                 request_method="POST")
-    @view_config(route_name='auth', match_param="action=out", renderer="string")
+    @view_config(route_name='auth', match_param='action=in', renderer='string',
+                 request_method='POST')
+    @view_config(route_name='auth', match_param='action=out', renderer='string')
     def sign_in_out(request):
         return {}
 

--- a/docs/initial_views_src.rst
+++ b/docs/initial_views_src.rst
@@ -14,31 +14,31 @@ Contents of views.py::
         User,
         )
     
-    @view_config(route_name='home', renderer="pyramid_blogr:templates/index.mako")
+    @view_config(route_name='home', renderer='pyramid_blogr:templates/index.mako')
     def index_page(request):
         return {}
     
     
-    @view_config(route_name='blog', renderer="pyramid_blogr:templates/view_blog.mako")
+    @view_config(route_name='blog', renderer='pyramid_blogr:templates/view_blog.mako')
     def blog_view(request):
         return {}
     
     
-    @view_config(route_name='blog_action', match_param="action=create",
-                 renderer="pyramid_blogr:templates/edit_blog.mako")
+    @view_config(route_name='blog_action', match_param='action=create',
+                 renderer='pyramid_blogr:templates/edit_blog.mako')
     def blog_create(request):
         return {}
     
     
-    @view_config(route_name='blog_action', match_param="action=edit",
-                 renderer="pyramid_blogr:templates/edit_blog.mako")
+    @view_config(route_name='blog_action', match_param='action=edit',
+                 renderer='pyramid_blogr:templates/edit_blog.mako')
     def blog_update(request):
         return {}
     
     
-    @view_config(route_name='auth', match_param="action=in", renderer="string",
-                 request_method="POST")
-    @view_config(route_name='auth', match_param="action=out", renderer="string")
+    @view_config(route_name='auth', match_param='action=in', renderer='string',
+                 request_method='POST')
+    @view_config(route_name='auth', match_param='action=out', renderer='string')
     def sign_in_out(request):
         return {}
 


### PR DESCRIPTION
While reading the docs I noticed that there were a lot of instances where single and double quotes were mixed where it wasn't needed. This simply replaces the double quotes with single where it matches the style guide.
