### PR TITLE
created_in_words: use UTC

### DIFF
--- a/pyramid_blogr/models/blog_record.py
+++ b/pyramid_blogr/models/blog_record.py
@@ -8,7 +8,7 @@ from sqlalchemy import (
     DateTime     #<- time abstraction field,
 )
 from webhelpers2.text import urlify #<- will generate slugs
-from webhelpers2.date import time_ago_in_words #<- human friendly dates
+from webhelpers2.date import distance_of_time_in_words #<- human friendly dates
 
 class BlogRecord(Base):
     __tablename__ = 'entries'
@@ -24,4 +24,6 @@ class BlogRecord(Base):
 
     @property
     def created_in_words(self):
-        return time_ago_in_words(self.created)
+        # Can't use time_ago_in_words(self.created) since self.created
+        # is UTC, but that function compares against local time
+        return distance_of_time_in_words(self.created, datetime.datetime.utcnow())


### PR DESCRIPTION
I couldn't figure out how to test this.

This fixes a problem: I ran the server, added a single entry, and noticed that the new entry claimed to have been created about seven hours ago, even though it was really created a few seconds ago.  I'm in PST8PDT, which is seven hours behind UTC, so ...